### PR TITLE
Pin aws-sdk to 2.304.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/gilt/s3-sftp-bridge/issues"
   },
   "dependencies": {
-    "aws-sdk": "2.x",
+    "aws-sdk": "2.304.0",
     "bluebird": "3.x",
     "node-s3-encryption-client": "^0.0.2",
     "ssh2": "^0.5.0"


### PR DESCRIPTION
Bluebird.promisifyAll does not work on aws-sdk@2.305.0 and above.

The version of aws-sdk provided in the Node8.10 environment is 2.488.0.
The quickstart template (https://github.com/aws-quickstart/connect-integration-teleopti-wfm) specifies Node8.10 as the runtime.